### PR TITLE
Bug fix on Syntax error when the last line in the template is code

### DIFF
--- a/jsrender.js
+++ b/jsrender.js
@@ -557,7 +557,10 @@ function buildTmplFunction( nodes ) {
 	for ( ; i < l; i++ ) {
 		node = nodes[ i ];
 		if ( node[ 0 ] === "*" ) {
-			code = code.slice( 0, -1 ) + ";" + node[ 1 ] + "result+=";
+			code = code.slice( 0, -1 ) + ";" + node[ 1 ];
+			if (i+1 < l) {
+			    code += "result+=";
+			}
 		} else {
 			code += nestedCall( node ) + "+";
 		}


### PR DESCRIPTION
When code is inserted within a template, if the last line of the template is code there is a syntax error and the template is not processed.
In buildTmplFunction, when the nodes are being processed and the code string is created, if the last line of the template is code and as such it contains {{*, at the end of the code string it is added "result+=", but that variable will not have any value as there is no more code nor template items.
Checking if it is really the last line before adding the string "result+=" avoids the syntax error.

In this example, there'd be a syntax error:

```
<script id="myTemplate" type="text/x-jquery-tmpl">
    {{=name}}
    {{*
        if ( $view.data.print ) {
    }} 
    <div>print</div>
    {{* } }}
</script>
```
