### PR TITLE
Minor correction to jsRender

### DIFF
--- a/jsrender.js
+++ b/jsrender.js
@@ -269,7 +269,10 @@
 			return self;
 		}
 		if (item === undefined) {
-			item = name;
+			if (name in store)
+				item = store[name];
+			else
+				item = name;			
 			name = undefined;
 		}
 		if (onStore = $viewsSub.onBeforeStoreItem) {


### PR DESCRIPTION
The $templates, $viewsTags, $viewsHelpers, and $viewsConverters functions all rely on the addToStore function. According to the comments on $templates, "Use var tmpl = $.templates( name ) or $.templates[name] or $.templates.name to return the object for the registered template." However, calling $.templates('mytemplate') will return "mytemplate" whereas $.templates['mytemplate'] will actually return the template.

After reviewing the code, I determined that a minor correction needed to be made to addToStore so that the code produced the expected results according to the comments as well as my own personal expectations. However, many examples of using $.template online rely on the old functionality. So, the corrections I made are as follows:

if the function call did not specify an item, and the name provided IS a key in the store: return a value from the store based on the key.

if the function call did not specify an item, and the name provided IS NOT a key in the store: perform the same action as before: set item value to the name provided

finally, set name to undefined in either case.

I ran into this problem because I was attempting to load templates externally and register them with jsRender using $.templates function through jQuery. I also wanted to be able to load templates externally and reference them in my other templates such as {{for data tmpl="template name" /}}. I was able to work around loading templates manually using the array instead of the function; however without the correction in the library itself, I could not register my own templates and use them directly from another template as demonstrated above.

After making the change to jsRender, I was able to not only load my templates externally, but reference them by name in other templates. I hope you will consider adding this minor change to the master branch.

Sincerely,
Steven Hunt
