### PR TITLE
Add #count property to get array length.

### DIFF
--- a/jsrender.js
+++ b/jsrender.js
@@ -241,6 +241,7 @@
 				views[self.key = "_" + parentView._useKey++] = self;
 				// self.index = is index of the parent
 				self.index = parentView.index;
+				self.count = parentView.count;
 			} else {
 				// Parent is an 'Array View'. Add this view to its views array
 				views.splice(
@@ -249,6 +250,7 @@
 					? key
 					: views.length,
 				0, self);
+				self.count = parentView.data.length;
 			}
 		}
 		return self;


### PR DESCRIPTION
Add `#count` property to get array length.

We can use `#parent.data.length` instead of it. However `#count` will makes possible to write more intuitive and readable template. See also #131.
