### PR TITLE
jQuery 1.9 markup parsing

### DIFF
--- a/jsrender.js
+++ b/jsrender.js
@@ -875,7 +875,7 @@
 							+ ",") : "") + 'params:"' + params + '"' + (passedCtx ? ",ctx:{" + passedCtx.slice(0, -1) + "}" : "") + "},",
 						noError,
 						//"{" + (hash ? ("props:{" + hash + "},") : "") + 'params:"' + params + '"' + (passedCtx ? ",ctx:{" + passedCtx.slice(0, -1) + "}" : "") + "},",
-						bind && pathBindings || 0,
+						bind && pathBindings || 0
 					];
 				content.push(newNode);
 				if (block) {


### PR DESCRIPTION
jQuery 1.9 will no longer parse markup that doesn't start with <, which broke most of my templates that I'm using. Trimming the resulted content fixes the issue.
