### PR TITLE
Added NPM package.json, added support to load as a Node.js module

### DIFF
--- a/jsrender.js
+++ b/jsrender.js
@@ -1467,3 +1467,5 @@
 	$viewsDelimiters();
 
 })(this, this.jQuery);
+
+if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') { module.exports = this.jsviews; }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+	"author": "Boris Moore",
+	"name": "jsrender",
+	"description": "Next-generation jQuery Templates, optimized for high-performance pure string-based rendering, without DOM or jQuery dependency.",
+	"version": "0.3.7",
+	"main": "./jsrender"
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
 	"author": "Boris Moore",
-	"name": "jsrender",
+	"name": "borismoore-jsrender",
 	"description": "Next-generation jQuery Templates, optimized for high-performance pure string-based rendering, without DOM or jQuery dependency.",
 	"version": "0.3.7",
-	"main": "./jsrender"
+	"dependencies": {},
+	"main": "./jsrender",
+	"engines": {
+		"node": "*"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
 	"name": "borismoore-jsrender",
 	"description": "Next-generation jQuery Templates, optimized for high-performance pure string-based rendering, without DOM or jQuery dependency.",
 	"version": "0.3.7",
-	"dependencies": {},
 	"main": "./jsrender",
 	"engines": {
 		"node": "*"


### PR DESCRIPTION
Hey Boris,

I have written a Node.js wrapper to easily interact with jsrender and want to publish it but I can't add jsrender as an NPM dependency unless the project has a package.json file in the repo. I've written one for you that should suffice.

I also modified your jsrender.js on the absolute last line to suppot a Node.js environment. This allows for loading in either Node or a browser without issue.

If you get a minute to publish this to NPM, you can run:

```
npm publish
```

To publish the repo to NPM. I realise this is probably pretty low priority for you right now as you are still doing beta candidate stuff but all the jsrender Node.js ports are outdated and use much older versions. Mine is using your repo as a base so as you update, it is updated automatically in my wrapper.

You can see my wrapper here: https://github.com/coolbloke1324/node-jsrender/

It's really very *very* simple but just creates a simple to use interface that means others won't need to read through any code to modify the client-side jsrender.js file to get it to run as a Node module. :)

I haven't published my wrapper to NPM yet because it will not actually install unless your project has a package.json file and is published to NPM as well. Didn't want to take the rude liberty of publishing your package for you either! :)