### PR TITLE
Fix memory leak when a template is removed from the DOM

### DIFF
--- a/jsrender.js
+++ b/jsrender.js
@@ -715,6 +715,8 @@ informal pre V1.0 commit counter: 52 */
 						// Use tmpl as options
 						value = $templates[name] = compileTmpl(name, elem.innerHTML, parentTmpl, storeName, storeSettings, options);
 					}
+
+					elem = null;
 				}
 				return value;
 			}


### PR DESCRIPTION
Hi,

If a template is used and then removed from the DOM, the template stays in the heap.

This pastebin has a simple demo of the leak: http://pastebin.com/yC6JxfEY

Basically, click the ON button, grab a heap snapshot, and then press the LEAK button and grab another snapshot. The template script will end up in a detached DOM tree in the heap.

Hope this helps!

Thanks,
Justin
